### PR TITLE
[codex] backend security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ The refresh flow validates the stored refresh token, email confirmation, and the
 
 Authorization is enforced through MediatR pipeline behavior. Use cases declare the required domain and action with the shared `Authorize` attribute, and the behavior checks the current user's permissions before the handler executes.
 
+## Backend Configuration
+
+CORS is configured with a single named policy from `Cors:AllowedOrigins`. Local development expects the frontend origin `http://localhost:5174`; override the setting per environment instead of enabling all origins.
+
+EF Core sensitive data logging is disabled by default. It is only enabled when the environment is `Development` and `Database:EnableSensitiveDataLogging` is explicitly set to `true`.
+
 ## Domain-Based Permissions
 
 Permissions are modeled around a domain and an action. Examples:

--- a/src/HomeControllerHUB.Api/ConfigureServices.cs
+++ b/src/HomeControllerHUB.Api/ConfigureServices.cs
@@ -7,13 +7,14 @@ using Microsoft.EntityFrameworkCore;
 using Asp.Versioning;
 using HomeControllerHUB.Infra.Settings;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.IdentityModel.Tokens;
 
 namespace HomeControllerHUB.Api;
 
 public static class ConfigureServices
 {
-    public static IServiceCollection ConfigureDatabase(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection ConfigureDatabase(this IServiceCollection services, IConfiguration configuration, IWebHostEnvironment environment)
     {
         services.AddDbContext<ApplicationDbContext>(options =>
         {
@@ -21,7 +22,11 @@ public static class ConfigureServices
                 x => x.MigrationsAssembly("HomeControllerHUB.Api"));
             options.LogTo(Console.WriteLine, LogLevel.Information);
             options.EnableDetailedErrors();
-            options.EnableSensitiveDataLogging();
+
+            if (environment.IsDevelopment() && configuration.GetValue<bool>("Database:EnableSensitiveDataLogging"))
+            {
+                options.EnableSensitiveDataLogging();
+            }
         });
 
         services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()

--- a/src/HomeControllerHUB.Api/HomeControllerHUB.Api.csproj
+++ b/src/HomeControllerHUB.Api/HomeControllerHUB.Api.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HomeControllerHUB.Api/Program.cs
+++ b/src/HomeControllerHUB.Api/Program.cs
@@ -26,7 +26,7 @@ Console.WriteLine("Home Controller HUB - ENV: " + builder.Environment.Environmen
 
 builder.Services.AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblyContaining<Program>());
 builder.Services.AddApplicationServices();
-builder.Services.ConfigureDatabase(builder.Configuration);
+builder.Services.ConfigureDatabase(builder.Configuration, builder.Environment);
 builder.Services.AddGlobalizationServices();
 builder.Services.AddInfra(builder.Configuration);
 builder.Services.AddDomainServices();
@@ -45,13 +45,15 @@ builder.Services.AddSingleton<ApplicationSettings>(sp =>
 });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddCustomOpenApi();
-const string allowedOrigins = "AllowAllOrigins";
+
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()
+    ?? ["http://localhost:5173"];
 
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy(allowedOrigins, policy =>
+    options.AddPolicy(GeneralConfigs.CORS, policy =>
     {
-        policy.AllowAnyOrigin()
+        policy.WithOrigins(allowedOrigins)
             .AllowAnyMethod()
             .AllowAnyHeader();
     });
@@ -75,10 +77,9 @@ if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Testing"))
 
 }
 
-app.UseCors(GeneralConfigs.CORS);
 app.UseMiddleware<ErrorHandlingMiddleware>();
 app.IntializeDatabase();
-app.UseCors(allowedOrigins);
+app.UseCors(GeneralConfigs.CORS);
 app.UseAuthentication();
 app.UseRateLimiter();
 app.UseAuthorization();

--- a/src/HomeControllerHUB.Api/appsettings.Development.json
+++ b/src/HomeControllerHUB.Api/appsettings.Development.json
@@ -25,6 +25,14 @@
     },
     "InitializeDataBase": "true"
   },
+  "Database": {
+    "EnableSensitiveDataLogging": true
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:5173"
+    ]
+  },
   "EmailSettings": {
     "MailgunApiKey": "your-mailgun-api-key",
     "MailgunDomain": "your-mailgun-domain",

--- a/src/HomeControllerHUB.Api/appsettings.Testing.json
+++ b/src/HomeControllerHUB.Api/appsettings.Testing.json
@@ -25,6 +25,14 @@
     },
     "InitializeDataBase": "true"
   },
+  "Database": {
+    "EnableSensitiveDataLogging": false
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:5173"
+    ]
+  },
   "RabbitMq": {
     "Host": "localhost",
     "Port": 5672,

--- a/src/HomeControllerHUB.Api/appsettings.json
+++ b/src/HomeControllerHUB.Api/appsettings.json
@@ -21,5 +21,13 @@
     "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
+  "Database": {
+    "EnableSensitiveDataLogging": false
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:5173"
+    ]
+  },
   "AllowedHosts": "*"
 }

--- a/src/HomeControllerHUB.Infra/ConfigureServices.cs
+++ b/src/HomeControllerHUB.Infra/ConfigureServices.cs
@@ -55,16 +55,6 @@ public static class ConfigureServices
         services.AddLocalization(options => options.ResourcesPath = "Resources");
         ConfigureRateLimiter(services);
 
-        services.AddCors(options =>
-        {
-            options.AddPolicy(name: GeneralConfigs.CORS,
-                              policy =>
-                              {
-                                  policy.WithOrigins("http://localhost:5173")
-                                    .AllowAnyHeader()
-                                    .AllowAnyMethod();
-                              });
-        });
         return services;
     }
 

--- a/src/HomeControllerHUB.Infra/Interceptors/AuthorizationBehaviour.cs
+++ b/src/HomeControllerHUB.Infra/Interceptors/AuthorizationBehaviour.cs
@@ -20,15 +20,25 @@ public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRe
 
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
-        var authorizeAttributes = request.GetType().GetCustomAttributes(typeof(AuthorizeAttribute), false) as AuthorizeAttribute[];
+        var authorizeAttributes = request.GetType()
+            .GetCustomAttributes(typeof(AuthorizeAttribute), false)
+            .OfType<AuthorizeAttribute>()
+            .ToArray();
         
-        if(authorizeAttributes.Length == 0) return await next();;
+        if (authorizeAttributes.Length == 0) return await next();
+
+        if (_currentUserService.UserId is null) throw new AppError(401, "Unauthorized");
 
         foreach (var attribute in authorizeAttributes)
         {
-           if (attribute.Domain == string.Empty) return await next();
-           var isAuthorized = await IsInDomainAndActionAsync(_currentUserService.UserId, attribute.Domain, attribute.Action);
-           if(!isAuthorized) throw new AppError(401, "Unauthorized");
+            if (attribute.Domain == string.Empty) continue;
+
+            var isAuthorized = await IsInDomainAndActionAsync(
+                _currentUserService.UserId,
+                attribute.Domain,
+                attribute.Action);
+
+            if (!isAuthorized) throw new AppError(401, "Unauthorized");
         }
         
         return await next();
@@ -48,15 +58,10 @@ public class AuthorizationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRe
             return false;
         }
         
-        var userHasAuthorization = await _context.UserProfiles
+        return await _context.UserProfiles
             .Where(x => x.UserId == userId)
             .SelectMany(up => up.Profile.ProfilePrivileges)
             .AnyAsync(pp => (pp.Privilege.DomainId == domainEntity.Id &&
                              pp.Privilege.Actions == action) || pp.Privilege.NormalizedName == "PLATFORMALL");
-
-        if (userHasAuthorization)
-            return true;
-
-        return false;
     }
 }

--- a/tests/HomeControllerHUB.Api.IntegrationTests/HealthChecksAndCorrelationTests.cs
+++ b/tests/HomeControllerHUB.Api.IntegrationTests/HealthChecksAndCorrelationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace HomeControllerHUB.Api.IntegrationTests;
@@ -107,6 +108,7 @@ public class HealthChecksWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseEnvironment("Testing");
         builder.UseSetting("ApplicationSettings:InitializeDataBase", "false");
+        builder.ConfigureLogging(logging => logging.ClearProviders());
 
         builder.ConfigureTestServices(services =>
         {

--- a/tests/HomeControllerHUB.Api.IntegrationTests/HomeControllerHUB.Api.IntegrationTests.csproj
+++ b/tests/HomeControllerHUB.Api.IntegrationTests/HomeControllerHUB.Api.IntegrationTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/tests/HomeControllerHUB.Application.Tests/AuditLogs/Interceptors/AuthorizationBehaviourTests.cs
+++ b/tests/HomeControllerHUB.Application.Tests/AuditLogs/Interceptors/AuthorizationBehaviourTests.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using HomeControllerHUB.Domain.Entities;
+using HomeControllerHUB.Domain.Interfaces;
+using HomeControllerHUB.Domain.Models;
+using HomeControllerHUB.Infra.DatabaseContext;
+using HomeControllerHUB.Infra.Interceptors;
+using HomeControllerHUB.Shared.Common;
+using HomeControllerHUB.Shared.Common.Constants;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace HomeControllerHUB.Application.Tests.AuditLogs.Interceptors;
+
+public class AuthorizationBehaviourTests
+{
+    [Fact]
+    public async Task Handle_ProtectedRequestWithoutRequiredPermission_ThrowsUnauthorized()
+    {
+        await using var context = CreateContext();
+        var userId = await SeedUserAsync(context);
+        var behaviour = CreateBehaviour<ProtectedRequest>(context, userId);
+
+        var act = async () => await behaviour.Handle(new ProtectedRequest(), () => Task.FromResult("handled"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<AppError>()
+            .Where(error => error.StatusCode == 401);
+    }
+
+    [Fact]
+    public async Task Handle_ProtectedRequestWithRequiredPermission_ExecutesHandler()
+    {
+        await using var context = CreateContext();
+        var userId = await SeedUserAsync(context, PrivilegeNames.UserRead, DomainNames.User, SecurityActionType.Read);
+        var behaviour = CreateBehaviour<ProtectedRequest>(context, userId);
+
+        var response = await behaviour.Handle(new ProtectedRequest(), () => Task.FromResult("handled"), CancellationToken.None);
+
+        response.Should().Be("handled");
+    }
+
+    [Fact]
+    public async Task Handle_ProtectedRequestWithPlatformAllPermission_ExecutesHandler()
+    {
+        await using var context = CreateContext();
+        var userId = await SeedUserAsync(context, PrivilegeNames.All, DomainNames.User, SecurityActionType.All);
+        var behaviour = CreateBehaviour<ProtectedRequest>(context, userId);
+
+        var response = await behaviour.Handle(new ProtectedRequest(), () => Task.FromResult("handled"), CancellationToken.None);
+
+        response.Should().Be("handled");
+    }
+
+    [Fact]
+    public async Task Handle_PublicRequest_ExecutesHandlerWithoutAuthenticatedUser()
+    {
+        await using var context = CreateContext();
+        var behaviour = CreateBehaviour<PublicRequest>(context, userId: null);
+
+        var response = await behaviour.Handle(new PublicRequest(), () => Task.FromResult("handled"), CancellationToken.None);
+
+        response.Should().Be("handled");
+    }
+
+    [Fact]
+    public async Task Handle_UnauthorizedProtectedRequest_DoesNotExecuteHandler()
+    {
+        await using var context = CreateContext();
+        var userId = await SeedUserAsync(context);
+        var behaviour = CreateBehaviour<ProtectedRequest>(context, userId);
+        var handlerExecuted = false;
+
+        var act = async () => await behaviour.Handle(
+            new ProtectedRequest(),
+            () =>
+            {
+                handlerExecuted = true;
+                return Task.FromResult("handled");
+            },
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<AppError>();
+        handlerExecuted.Should().BeFalse();
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var currentUserService = new Mock<ICurrentUserService>();
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase($"authorization-tests-{Guid.NewGuid():N}")
+            .Options;
+
+        return new ApplicationDbContext(
+            options,
+            new NormalizedInterceptor(),
+            new BaseEntityInterceptor(currentUserService.Object));
+    }
+
+    private static AuthorizationBehaviour<TRequest, string> CreateBehaviour<TRequest>(
+        ApplicationDbContext context,
+        Guid? userId)
+        where TRequest : IRequest<string>
+    {
+        var currentUserService = new Mock<ICurrentUserService>();
+        currentUserService.Setup(service => service.UserId).Returns(userId);
+        currentUserService.Setup(service => service.Login).Returns("authorization-test");
+
+        return new AuthorizationBehaviour<TRequest, string>(currentUserService.Object, context);
+    }
+
+    private static async Task<Guid> SeedUserAsync(
+        ApplicationDbContext context,
+        string? privilegeName = null,
+        string? domainName = null,
+        string? action = null)
+    {
+        var establishment = new Establishment
+        {
+            Id = Guid.NewGuid(),
+            Code = "AUTH-EST",
+            Name = "Authorization Test",
+            NormalizedName = "AUTHORIZATION TEST",
+            SiteName = "Authorization Test",
+            NormalizedSiteName = "AUTHORIZATION TEST",
+            Document = "12345678901",
+            Enable = true,
+            IsMaster = true
+        };
+
+        var user = new ApplicationUser
+        {
+            Id = Guid.NewGuid(),
+            EstablishmentId = establishment.Id,
+            Establishment = establishment,
+            Code = "AUTH-USER",
+            UserName = "authorization-test",
+            NormalizedUserName = "AUTHORIZATION-TEST",
+            Name = "Authorization Test",
+            NormalizedName = "AUTHORIZATION TEST",
+            Email = "authorization@test.local",
+            NormalizedEmail = "AUTHORIZATION@TEST.LOCAL",
+            Login = "authorization-test",
+            PasswordHash = "hash",
+            Enable = true
+        };
+
+        context.Establishments.Add(establishment);
+        context.Users.Add(user);
+
+        if (privilegeName is not null && domainName is not null && action is not null)
+        {
+            var domain = new ApplicationDomain
+            {
+                Id = Guid.NewGuid(),
+                Name = domainName,
+                NormalizedName = domainName.ToUpperInvariant(),
+                Enable = true
+            };
+
+            var profile = new Profile
+            {
+                Id = Guid.NewGuid(),
+                EstablishmentId = establishment.Id,
+                Establishment = establishment,
+                Name = "Authorization Profile",
+                NormalizedName = "AUTHORIZATION PROFILE",
+                Enable = true
+            };
+
+            var privilege = new Privilege
+            {
+                Id = Guid.NewGuid(),
+                Name = privilegeName,
+                NormalizedName = privilegeName.Replace("-", string.Empty).ToUpperInvariant(),
+                Description = privilegeName,
+                NormalizedDescription = privilegeName.ToUpperInvariant(),
+                Actions = action,
+                DomainId = domain.Id,
+                Domain = domain,
+                EstablishmentId = establishment.Id,
+                Establishment = establishment,
+                Enable = true
+            };
+
+            context.Domains.Add(domain);
+            context.Profiles.Add(profile);
+            context.Privilege.Add(privilege);
+            context.ProfilePrivileges.Add(new ProfilePrivilege
+            {
+                ProfileId = profile.Id,
+                Profile = profile,
+                PrivilegeId = privilege.Id,
+                Privilege = privilege
+            });
+            context.UserProfiles.Add(new UserProfile
+            {
+                UserId = user.Id,
+                User = user,
+                ProfileId = profile.Id,
+                Profile = profile
+            });
+        }
+
+        await context.SaveChangesAsync();
+
+        return user.Id;
+    }
+
+    [Authorize(Domain = DomainNames.User, Action = SecurityActionType.Read)]
+    private sealed record ProtectedRequest : IRequest<string>;
+
+    private sealed record PublicRequest : IRequest<string>;
+}

--- a/tests/HomeControllerHUB.Application.Tests/HomeControllerHUB.Application.Tests.csproj
+++ b/tests/HomeControllerHUB.Application.Tests/HomeControllerHUB.Application.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
## Summary

- Re-enabled and tightened MediatR authorization behavior for domain/action checks, authenticated [Authorize] requests, and platform-all access.
- Restricted EF Core sensitive data logging to explicit Development configuration and replaced permissive/duplicated CORS with a single configured policy.
- Mitigated vulnerable transitive NuGet packages and added authorization pipeline coverage.

## Validation

- dotnet build HomeControllerHUB.sln --no-restore
- dotnet test tests/HomeControllerHUB.Application.Tests/HomeControllerHUB.Application.Tests.csproj --no-restore (passed earlier with Docker/Testcontainers access: 179 passed)
- dotnet test tests/HomeControllerHUB.Api.IntegrationTests/HomeControllerHUB.Api.IntegrationTests.csproj --no-restore
- dotnet test tests/HomeControllerHUB.Domain.Tests/HomeControllerHUB.Domain.Tests.csproj --no-restore
- dotnet list HomeControllerHUB.sln package --vulnerable --include-transitive (clean after package updates)

## Notes

Manual browser/frontend validation was not run in this workspace.