### PR TITLE
Add automatic sensor health monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,29 @@ The API currently hosts the MassTransit consumer in the same process. The consum
 
 Idempotency is enforced by `messageId` with a unique `SensorId + MessageId` index. The consumer checks for an existing reading before insert and handles unique-index races by returning `status: "Duplicate"` without creating another reading.
 
+## Sensor Health Monitoring
+
+The API runs an automatic sensor health monitor as a hosted service. It periodically sends a MediatR command that checks active sensors and creates technical alerts when a sensor is offline or has low battery.
+
+An active sensor is considered offline when `LastCommunication` has not been set by telemetry yet or is older than `SensorHealthMonitoring:OfflineThresholdMinutes`. A low-battery alert is created when `BatteryLevel` is present and lower than `SensorHealthMonitoring:LowBatteryThreshold`.
+
+The monitor does not create duplicate pending alerts for the same `SensorId` and alert type (`DeviceOffline` or `BatteryLow`). It also does not automatically acknowledge alerts when the sensor recovers.
+
+Configuration:
+
+```json
+{
+  "SensorHealthMonitoring": {
+    "Enabled": true,
+    "IntervalSeconds": 60,
+    "OfflineThresholdMinutes": 10,
+    "LowBatteryThreshold": 20
+  }
+}
+```
+
+These automatic technical alerts are not user actions and do not create audit log entries.
+
 RabbitMQ is part of the readiness check:
 
 ```text
@@ -576,6 +599,10 @@ Important configuration areas:
 - `RabbitMq:Password`
 - `RabbitMq:QueueName`
 - `RabbitMq:PublishTimeoutSeconds`
+- `SensorHealthMonitoring:Enabled`
+- `SensorHealthMonitoring:IntervalSeconds`
+- `SensorHealthMonitoring:OfflineThresholdMinutes`
+- `SensorHealthMonitoring:LowBatteryThreshold`
 
 Do not commit real database credentials, JWT secrets, Mailgun keys, refresh tokens, sensor API keys, or production URLs.
 

--- a/src/HomeControllerHUB.Api/HostedServices/SensorHealthMonitoringHostedService.cs
+++ b/src/HomeControllerHUB.Api/HostedServices/SensorHealthMonitoringHostedService.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+using HomeControllerHUB.Application.Sensors.Commands.MonitorSensorHealth;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace HomeControllerHUB.Api.HostedServices;
+
+public class SensorHealthMonitoringHostedService : BackgroundService
+{
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<SensorHealthMonitoringHostedService> _logger;
+    private readonly SensorHealthMonitoringOptions _options;
+
+    public SensorHealthMonitoringHostedService(
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<SensorHealthMonitoringHostedService> logger,
+        IOptions<SensorHealthMonitoringOptions> options)
+    {
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+        _options = options.Value;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("Sensor health monitoring is disabled");
+            return;
+        }
+
+        var interval = TimeSpan.FromSeconds(_options.EffectiveIntervalSeconds);
+
+        await RunMonitoringAsync(stoppingToken);
+
+        using var timer = new PeriodicTimer(interval);
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await RunMonitoringAsync(stoppingToken);
+        }
+    }
+
+    private async Task RunMonitoringAsync(CancellationToken stoppingToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using var scope = _serviceScopeFactory.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            var result = await mediator.Send(new MonitorSensorHealthCommand(), stoppingToken);
+
+            stopwatch.Stop();
+            _logger.LogInformation(
+                "Sensor health monitoring completed. SensorsChecked={SensorsChecked} OfflineAlertsCreated={OfflineAlertsCreated} LowBatteryAlertsCreated={LowBatteryAlertsCreated} DuplicateAlertsSkipped={DuplicateAlertsSkipped} DurationMs={DurationMs}",
+                result.SensorsChecked,
+                result.OfflineAlertsCreated,
+                result.LowBatteryAlertsCreated,
+                result.DuplicateAlertsSkipped,
+                stopwatch.ElapsedMilliseconds);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            _logger.LogError(
+                ex,
+                "Error occurred during sensor health monitoring. DurationMs={DurationMs}",
+                stopwatch.ElapsedMilliseconds);
+        }
+    }
+}

--- a/src/HomeControllerHUB.Api/Program.cs
+++ b/src/HomeControllerHUB.Api/Program.cs
@@ -4,8 +4,10 @@ using HomeControllerHUB.Api;
 using HomeControllerHUB.Api.Controllers;
 using HomeControllerHUB.Api.Extensions;
 using HomeControllerHUB.Api.HealthChecks;
+using HomeControllerHUB.Api.HostedServices;
 using HomeControllerHUB.Api.Middlewares;
 using HomeControllerHUB.Application;
+using HomeControllerHUB.Application.Sensors.Commands.MonitorSensorHealth;
 using HomeControllerHUB.Domain;
 using HomeControllerHUB.Globalization;
 using HomeControllerHUB.Infra;
@@ -31,6 +33,9 @@ builder.Services.AddGlobalizationServices();
 builder.Services.AddInfra(builder.Configuration);
 builder.Services.AddDomainServices();
 builder.Services.AddHomeControllerHubMessageBus(builder.Configuration, builder.Environment);
+builder.Services.Configure<SensorHealthMonitoringOptions>(
+    builder.Configuration.GetSection(SensorHealthMonitoringOptions.SectionName));
+builder.Services.AddHostedService<SensorHealthMonitoringHostedService>();
 builder.Services.AddHealthChecks()
     .AddCheck("application", () => Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult.Healthy("Application is running"), tags: new[] { "live", "ready" })
     .AddCheck<ApplicationDbContextHealthCheck>("database", tags: new[] { "ready" })

--- a/src/HomeControllerHUB.Api/appsettings.Development.json
+++ b/src/HomeControllerHUB.Api/appsettings.Development.json
@@ -49,6 +49,12 @@
     "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
+  "SensorHealthMonitoring": {
+    "Enabled": true,
+    "IntervalSeconds": 60,
+    "OfflineThresholdMinutes": 10,
+    "LowBatteryThreshold": 20
+  },
   "Kestrel": {
     "Endpoints": {
       "Http": {

--- a/src/HomeControllerHUB.Api/appsettings.Testing.json
+++ b/src/HomeControllerHUB.Api/appsettings.Testing.json
@@ -42,6 +42,12 @@
     "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
+  "SensorHealthMonitoring": {
+    "Enabled": false,
+    "IntervalSeconds": 60,
+    "OfflineThresholdMinutes": 10,
+    "LowBatteryThreshold": 20
+  },
   "Kestrel": {
     "Endpoints": {
       "Http": {

--- a/src/HomeControllerHUB.Api/appsettings.json
+++ b/src/HomeControllerHUB.Api/appsettings.json
@@ -21,6 +21,12 @@
     "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
+  "SensorHealthMonitoring": {
+    "Enabled": true,
+    "IntervalSeconds": 60,
+    "OfflineThresholdMinutes": 10,
+    "LowBatteryThreshold": 20
+  },
   "Database": {
     "EnableSensitiveDataLogging": false
   },

--- a/src/HomeControllerHUB.Application/Sensors/Commands/MonitorSensorHealth/MonitorSensorHealthCommand.cs
+++ b/src/HomeControllerHUB.Application/Sensors/Commands/MonitorSensorHealth/MonitorSensorHealthCommand.cs
@@ -1,0 +1,173 @@
+using System.Globalization;
+using HomeControllerHUB.Domain.Entities;
+using HomeControllerHUB.Domain.Interfaces;
+using HomeControllerHUB.Globalization;
+using HomeControllerHUB.Infra.DatabaseContext;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace HomeControllerHUB.Application.Sensors.Commands.MonitorSensorHealth;
+
+public class MonitorSensorHealthCommand : IRequest<MonitorSensorHealthResult>
+{
+}
+
+public class MonitorSensorHealthResult
+{
+    public int SensorsChecked { get; set; }
+    public int OfflineAlertsCreated { get; set; }
+    public int LowBatteryAlertsCreated { get; set; }
+    public int DuplicateAlertsSkipped { get; set; }
+}
+
+public class MonitorSensorHealthCommandHandler : IRequestHandler<MonitorSensorHealthCommand, MonitorSensorHealthResult>
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IDateTime _dateTime;
+    private readonly ISharedResource _sharedResource;
+    private readonly SensorHealthMonitoringOptions _options;
+
+    public MonitorSensorHealthCommandHandler(
+        ApplicationDbContext context,
+        IDateTime dateTime,
+        ISharedResource sharedResource,
+        IOptions<SensorHealthMonitoringOptions> options)
+    {
+        _context = context;
+        _dateTime = dateTime;
+        _sharedResource = sharedResource;
+        _options = options.Value;
+    }
+
+    public async Task<MonitorSensorHealthResult> Handle(
+        MonitorSensorHealthCommand request,
+        CancellationToken cancellationToken)
+    {
+        var now = _dateTime.UtcNow;
+        var offlineThresholdMinutes = _options.EffectiveOfflineThresholdMinutes;
+        var offlineCutoff = now.AddMinutes(-offlineThresholdMinutes);
+
+        var activeSensors = await _context.Sensors
+            .Where(sensor => sensor.IsActive)
+            .ToListAsync(cancellationToken);
+
+        var result = new MonitorSensorHealthResult
+        {
+            SensorsChecked = activeSensors.Count
+        };
+
+        if (activeSensors.Count == 0)
+        {
+            return result;
+        }
+
+        var sensorIds = activeSensors.Select(sensor => sensor.Id).ToList();
+        var pendingAlerts = await _context.SensorAlerts
+            .AsNoTracking()
+            .Where(alert => sensorIds.Contains(alert.SensorId)
+                            && !alert.IsAcknowledged
+                            && (alert.Type == AlertType.DeviceOffline || alert.Type == AlertType.BatteryLow))
+            .Select(alert => new { alert.SensorId, alert.Type })
+            .ToListAsync(cancellationToken);
+
+        var pendingAlertKeys = pendingAlerts
+            .Select(alert => (alert.SensorId, alert.Type))
+            .ToHashSet();
+
+        var alertsToCreate = new List<SensorAlert>();
+
+        foreach (var sensor in activeSensors)
+        {
+            if (IsOffline(sensor, offlineCutoff))
+            {
+                TryAddAlert(
+                    sensor,
+                    AlertType.DeviceOffline,
+                    CreateOfflineMessage(sensor, offlineThresholdMinutes),
+                    now,
+                    pendingAlertKeys,
+                    alertsToCreate,
+                    result,
+                    created => result.OfflineAlertsCreated = created);
+            }
+
+            if (IsLowBattery(sensor, _options.LowBatteryThreshold))
+            {
+                TryAddAlert(
+                    sensor,
+                    AlertType.BatteryLow,
+                    CreateLowBatteryMessage(sensor),
+                    now,
+                    pendingAlertKeys,
+                    alertsToCreate,
+                    result,
+                    created => result.LowBatteryAlertsCreated = created);
+            }
+        }
+
+        if (alertsToCreate.Count > 0)
+        {
+            await _context.SensorAlerts.AddRangeAsync(alertsToCreate, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        return result;
+    }
+
+    private static bool IsOffline(Sensor sensor, DateTime offlineCutoff)
+    {
+        return sensor.LastCommunication == default || sensor.LastCommunication < offlineCutoff;
+    }
+
+    private static bool IsLowBattery(Sensor sensor, double lowBatteryThreshold)
+    {
+        return sensor.BatteryLevel.HasValue && sensor.BatteryLevel.Value < lowBatteryThreshold;
+    }
+
+    private static void TryAddAlert(
+        Sensor sensor,
+        AlertType alertType,
+        string message,
+        DateTime timestamp,
+        ISet<(Guid SensorId, AlertType AlertType)> pendingAlertKeys,
+        ICollection<SensorAlert> alertsToCreate,
+        MonitorSensorHealthResult result,
+        Action<int> updateCreatedCount)
+    {
+        var alertKey = (sensor.Id, alertType);
+        if (pendingAlertKeys.Contains(alertKey))
+        {
+            result.DuplicateAlertsSkipped++;
+            return;
+        }
+
+        alertsToCreate.Add(new SensorAlert
+        {
+            SensorId = sensor.Id,
+            Type = alertType,
+            Message = message,
+            Timestamp = timestamp,
+            IsAcknowledged = false
+        });
+
+        pendingAlertKeys.Add(alertKey);
+        updateCreatedCount(alertType == AlertType.DeviceOffline
+            ? result.OfflineAlertsCreated + 1
+            : result.LowBatteryAlertsCreated + 1);
+    }
+
+    private string CreateOfflineMessage(Sensor sensor, int offlineThresholdMinutes)
+    {
+        return string.Format(
+            CultureInfo.CurrentCulture,
+            _sharedResource.Message("SensorOffline"),
+            sensor.Name,
+            offlineThresholdMinutes);
+    }
+
+    private string CreateLowBatteryMessage(Sensor sensor)
+    {
+        return $"{_sharedResource.Message("SensorLowBattery")}: {sensor.Name}";
+    }
+}

--- a/src/HomeControllerHUB.Application/Sensors/Commands/MonitorSensorHealth/SensorHealthMonitoringOptions.cs
+++ b/src/HomeControllerHUB.Application/Sensors/Commands/MonitorSensorHealth/SensorHealthMonitoringOptions.cs
@@ -1,0 +1,19 @@
+namespace HomeControllerHUB.Application.Sensors.Commands.MonitorSensorHealth;
+
+public class SensorHealthMonitoringOptions
+{
+    public const string SectionName = "SensorHealthMonitoring";
+    public const int DefaultIntervalSeconds = 60;
+    public const int DefaultOfflineThresholdMinutes = 10;
+    public const double DefaultLowBatteryThreshold = 20;
+    public const int MinimumIntervalSeconds = 1;
+    public const int MinimumOfflineThresholdMinutes = 1;
+
+    public bool Enabled { get; set; } = true;
+    public int IntervalSeconds { get; set; } = DefaultIntervalSeconds;
+    public int OfflineThresholdMinutes { get; set; } = DefaultOfflineThresholdMinutes;
+    public double LowBatteryThreshold { get; set; } = DefaultLowBatteryThreshold;
+
+    public int EffectiveIntervalSeconds => Math.Max(MinimumIntervalSeconds, IntervalSeconds);
+    public int EffectiveOfflineThresholdMinutes => Math.Max(MinimumOfflineThresholdMinutes, OfflineThresholdMinutes);
+}

--- a/src/HomeControllerHUB.Globalization/Resources/SharedResource.en.resx
+++ b/src/HomeControllerHUB.Globalization/Resources/SharedResource.en.resx
@@ -87,6 +87,9 @@
     <data name="SensorLowBattery" xml:space="preserve">
         <value>Sensor with low battery</value>
     </data>
+    <data name="SensorOffline" xml:space="preserve">
+        <value>Sensor {0} has not communicated for more than {1} minutes.</value>
+    </data>
     <data name="InvalidLogin" xml:space="preserve">
         <value>Invalid login</value>
     </data>

--- a/src/HomeControllerHUB.Globalization/Resources/SharedResource.pt-BR.resx
+++ b/src/HomeControllerHUB.Globalization/Resources/SharedResource.pt-BR.resx
@@ -87,6 +87,9 @@
     <data name="SensorLowBattery" xml:space="preserve">
         <value>Sensor está com a bateria baixa</value>
     </data>
+    <data name="SensorOffline" xml:space="preserve">
+        <value>Sensor {0} está sem comunicação há mais de {1} minutos.</value>
+    </data>
     <data name="InvalidLogin" xml:space="preserve">
         <value>Login inválido</value>
     </data>

--- a/tests/HomeControllerHUB.Application.Tests/Sensors/Commands/MonitorSensorHealthCommandTest.cs
+++ b/tests/HomeControllerHUB.Application.Tests/Sensors/Commands/MonitorSensorHealthCommandTest.cs
@@ -1,0 +1,236 @@
+using FluentAssertions;
+using HomeControllerHUB.Application.Sensors.Commands.MonitorSensorHealth;
+using HomeControllerHUB.Application.Sensors.Commands.ProcessSensorReading;
+using HomeControllerHUB.Domain.Entities;
+using HomeControllerHUB.Domain.Interfaces;
+using HomeControllerHUB.Globalization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace HomeControllerHUB.Application.Tests.Sensors;
+
+public class MonitorSensorHealthCommandTest : TestConfigs
+{
+    private readonly DateTime _now = new(2026, 7, 5, 12, 0, 0, DateTimeKind.Utc);
+    private readonly Mock<IDateTime> _dateTimeMock;
+    private readonly Mock<ISharedResource> _resourceMock;
+
+    public MonitorSensorHealthCommandTest()
+    {
+        _dateTimeMock = new Mock<IDateTime>();
+        _dateTimeMock.Setup(dateTime => dateTime.UtcNow).Returns(_now);
+
+        _resourceMock = new Mock<ISharedResource>();
+        _resourceMock.Setup(resource => resource.Message(It.IsAny<string>()))
+            .Returns((string key) => key);
+        _resourceMock.Setup(resource => resource.Message("SensorOffline"))
+            .Returns("Sensor {0} has not communicated for more than {1} minutes.");
+        _resourceMock.Setup(resource => resource.Message("SensorLowBattery"))
+            .Returns("Sensor with low battery");
+        _resourceMock.Setup(resource => resource.NotFoundMessage(It.IsAny<string>()))
+            .Returns((string entity) => $"{entity} not found");
+    }
+
+    [Fact]
+    public async Task Monitor_Should_CreateOfflineAlert_WhenActiveSensorHasNoLastCommunication()
+    {
+        var sensor = await CreateSensorAsync(
+            lastCommunication: new DateTime(1, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.SensorsChecked.Should().Be(1);
+        result.OfflineAlertsCreated.Should().Be(1);
+        _context.SensorAlerts.Should().ContainSingle(alert =>
+            alert.SensorId == sensor.Id && alert.Type == AlertType.DeviceOffline && !alert.IsAcknowledged);
+    }
+
+    [Fact]
+    public async Task Monitor_Should_CreateOfflineAlert_WhenActiveSensorCommunicationIsOld()
+    {
+        var sensor = await CreateSensorAsync(lastCommunication: _now.AddMinutes(-11));
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.OfflineAlertsCreated.Should().Be(1);
+        _context.SensorAlerts.Should().ContainSingle(alert =>
+            alert.SensorId == sensor.Id && alert.Type == AlertType.DeviceOffline);
+    }
+
+    [Fact]
+    public async Task Monitor_Should_NotCreateOfflineAlert_WhenActiveSensorCommunicationIsRecent()
+    {
+        await CreateSensorAsync(lastCommunication: _now.AddMinutes(-9));
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.OfflineAlertsCreated.Should().Be(0);
+        _context.SensorAlerts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Monitor_Should_NotCreateOfflineAlert_WhenSensorIsInactive()
+    {
+        await CreateSensorAsync(isActive: false, lastCommunication: _now.AddHours(-1));
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.SensorsChecked.Should().Be(0);
+        result.OfflineAlertsCreated.Should().Be(0);
+        _context.SensorAlerts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Monitor_Should_CreateLowBatteryAlert_WhenBatteryIsBelowThreshold()
+    {
+        var sensor = await CreateSensorAsync(lastCommunication: _now, batteryLevel: 19);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.LowBatteryAlertsCreated.Should().Be(1);
+        _context.SensorAlerts.Should().ContainSingle(alert =>
+            alert.SensorId == sensor.Id && alert.Type == AlertType.BatteryLow && !alert.IsAcknowledged);
+    }
+
+    [Fact]
+    public async Task Monitor_Should_NotCreateLowBatteryAlert_WhenBatteryIsNormal()
+    {
+        await CreateSensorAsync(lastCommunication: _now, batteryLevel: 20);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.LowBatteryAlertsCreated.Should().Be(0);
+        _context.SensorAlerts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Monitor_Should_SkipDuplicate_WhenPendingAlertExistsForSameSensorAndType()
+    {
+        var sensor = await CreateSensorAsync(lastCommunication: _now.AddHours(-1));
+        _context.SensorAlerts.Add(new SensorAlert
+        {
+            SensorId = sensor.Id,
+            Type = AlertType.DeviceOffline,
+            Message = "Existing offline alert",
+            Timestamp = _now.AddMinutes(-30),
+            IsAcknowledged = false
+        });
+        await _context.SaveChangesAsync();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.OfflineAlertsCreated.Should().Be(0);
+        result.DuplicateAlertsSkipped.Should().Be(1);
+        _context.SensorAlerts.Count(alert =>
+            alert.SensorId == sensor.Id && alert.Type == AlertType.DeviceOffline).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Monitor_Should_ReturnCorrectSummary_ForMultipleSensors()
+    {
+        await CreateSensorAsync(lastCommunication: _now.AddHours(-1), batteryLevel: 90);
+        await CreateSensorAsync(lastCommunication: _now, batteryLevel: 10);
+        await CreateSensorAsync(lastCommunication: _now.AddHours(-2), batteryLevel: 5);
+        await CreateSensorAsync(isActive: false, lastCommunication: _now.AddHours(-3), batteryLevel: 1);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        result.SensorsChecked.Should().Be(3);
+        result.OfflineAlertsCreated.Should().Be(2);
+        result.LowBatteryAlertsCreated.Should().Be(2);
+        result.DuplicateAlertsSkipped.Should().Be(0);
+        _context.SensorAlerts.Count().Should().Be(4);
+    }
+
+    [Fact]
+    public async Task Monitor_Should_NotCreateAuditLog()
+    {
+        await CreateSensorAsync(lastCommunication: _now.AddHours(-1));
+        var handler = CreateHandler();
+
+        await handler.Handle(new MonitorSensorHealthCommand(), CancellationToken.None);
+
+        _context.AuditLogs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ProcessReading_Should_KeepCreatingThresholdAlert_WhenValueExceedsMaxThreshold()
+    {
+        var sensor = await CreateSensorAsync(lastCommunication: _now, maxThreshold: 30);
+        var handler = new ProcessSensorReadingCommandHandler(
+            _context,
+            _resourceMock.Object,
+            NullLogger<ProcessSensorReadingCommandHandler>.Instance);
+
+        var response = await handler.Handle(new ProcessSensorReadingCommand
+        {
+            SensorId = sensor.Id,
+            DeviceId = sensor.DeviceId,
+            MessageId = "threshold-message-1",
+            Timestamp = _now,
+            Value = 31,
+            Unit = "C"
+        }, CancellationToken.None);
+
+        response.AlertCreated.Should().BeTrue();
+        _context.SensorAlerts.Should().ContainSingle(alert =>
+            alert.SensorId == sensor.Id && alert.Type == AlertType.ThresholdExceeded);
+    }
+
+    private MonitorSensorHealthCommandHandler CreateHandler(
+        int offlineThresholdMinutes = 10,
+        double lowBatteryThreshold = 20)
+    {
+        return new MonitorSensorHealthCommandHandler(
+            _context,
+            _dateTimeMock.Object,
+            _resourceMock.Object,
+            Options.Create(new SensorHealthMonitoringOptions
+            {
+                OfflineThresholdMinutes = offlineThresholdMinutes,
+                LowBatteryThreshold = lowBatteryThreshold
+            }));
+    }
+
+    private async Task<Sensor> CreateSensorAsync(
+        bool isActive = true,
+        DateTime? lastCommunication = null,
+        double? batteryLevel = null,
+        double? maxThreshold = null)
+    {
+        var establishment = await CreateEstablishment();
+        var location = new Location
+        {
+            EstablishmentId = establishment.Id,
+            Name = $"Location {Guid.NewGuid():N}"
+        };
+
+        var sensor = new Sensor
+        {
+            EstablishmentId = establishment.Id,
+            Location = location,
+            Name = $"Sensor {Guid.NewGuid():N}",
+            DeviceId = $"DEVICE-{Guid.NewGuid():N}",
+            Model = "ESP32",
+            Type = SensorType.Temperature,
+            IsActive = isActive,
+            LastCommunication = lastCommunication ?? _now,
+            BatteryLevel = batteryLevel,
+            MaxThreshold = maxThreshold
+        };
+
+        _context.Sensors.Add(sensor);
+        await _context.SaveChangesAsync();
+
+        return sensor;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds automatic sensor health monitoring through a reusable MediatR command.
- Adds a background service that periodically checks active sensors.
- Creates `DeviceOffline` alerts for active sensors without recent communication.
- Creates `BatteryLow` alerts for active sensors below the configured battery threshold.
- Prevents duplicate pending alerts for the same sensor and alert type.
- Keeps the monitoring configurable through `SensorHealthMonitoring` settings.
- Keeps the hosted service disabled in Testing to avoid test flakiness.
- Adds tests for offline detection, low battery detection, duplicate prevention, inactive sensors and normal sensors.
- Updates documentation and localization resources.

## Configuration

The feature uses the following configuration section:

```json
SensorHealthMonitoring: {
  Enabled: true,
  IntervalSeconds: 60,
  OfflineThresholdMinutes: 10,
  LowBatteryThreshold: 20
}
```

## Validation

* `dotnet build HomeControllerHUB.sln --configuration Release`
* `dotnet test tests/HomeControllerHUB.Domain.Tests/HomeControllerHUB.Domain.Tests.csproj --configuration Release --no-build`
* `dotnet test tests/HomeControllerHUB.Application.Tests/HomeControllerHUB.Application.Tests.csproj --configuration Release --no-build`
* `dotnet test tests/HomeControllerHUB.Api.IntegrationTests/HomeControllerHUB.Api.IntegrationTests.csproj --configuration Release --no-build`
* `dotnet list HomeControllerHUB.sln package --vulnerable --include-transitive`

## Manual validation

* Active sensor with old/default `LastCommunication` created one pending `DeviceOffline` alert.
* Active sensor with low `BatteryLevel` created one pending `BatteryLow` alert.
* Re-running the monitor did not duplicate pending alerts.
* Active healthy sensor did not create alerts.
* Inactive sensor did not create alerts.
* Automatic monitoring did not create audit logs.
* Frontend dashboard, alerts page and sensor details were validated.
* Browser console had no relevant errors.

## Notes

* No database migration was required.
* No frontend changes were required.
* `LastCommunication == default(DateTime)` is treated as no communication because the current entity contract is not nullable.