### PR TITLE
Clean up MassTransit endpoint registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Example payload:
 
 `messageId`, `deviceId`, `value`, and `X-Api-Key` are required. `timestamp` is optional and falls back to `DateTime.UtcNow`. `batteryLevel` is optional and updates the sensor when provided. `rawData` is stored as JSON text for diagnostic data.
 
-After validation, the API sends a `SensorTelemetryReceivedMessage` to the configured RabbitMQ queue through MassTransit and returns `202 Accepted`:
+After validation, the API publishes a `SensorTelemetryReceivedMessage` through MassTransit and returns `202 Accepted`:
 
 ```json
 {
@@ -179,10 +179,10 @@ After validation, the API sends a `SensorTelemetryReceivedMessage` to the config
 
 If the same message was already processed and stored, the endpoint can return `status: "Duplicate"` instead of publishing another message. If a duplicate is still waiting in the queue, returning `Queued` is acceptable because idempotency is enforced by the consumer.
 
-The main queue is:
+MassTransit discovers consumers in the API assembly and creates their receive endpoints automatically. With the kebab-case endpoint name formatter, the telemetry queue is:
 
 ```text
-homecontrollerhub.sensor-telemetry
+sensor-telemetry-received
 ```
 
 The queued message contains `SensorId`, `DeviceId`, `MessageId`, `Timestamp`, `Value`, `Unit`, `BatteryLevel`, `RawData`, `ReceivedAt`, and `CorrelationId`. It does not contain API keys, user tokens, authorization headers, passwords, or secrets.
@@ -192,7 +192,7 @@ MassTransit configures a durable receive endpoint for the telemetry queue. The r
 If the consumer keeps failing after retries, MassTransit moves the message to its standard error queue. Operationally, this is the telemetry DLQ:
 
 ```text
-homecontrollerhub.sensor-telemetry_error
+sensor-telemetry-received_error
 ```
 
 The API currently hosts the MassTransit consumer in the same process. The consumer calls the application processing command, which creates `SensorReading`, updates `LastCommunication`, updates `BatteryLevel` when present, and evaluates `MinThreshold`/`MaxThreshold`. Threshold violations create `SensorAlert` records unless there is already an unacknowledged alert for the same sensor and alert type.
@@ -263,7 +263,6 @@ RabbitMQ appsettings:
     "VirtualHost": "/",
     "Username": "guest",
     "Password": "guest",
-    "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   }
 }
@@ -349,11 +348,11 @@ Manual validation flow:
 4. Confirm the database has sensors with matching local/demo `deviceId` and `apiKey`.
 5. Configure `sensor-simulator.local.json`.
 6. Run the simulator and confirm `queued` responses.
-7. Confirm messages arrive and are consumed from `homecontrollerhub.sensor-telemetry`.
+7. Confirm messages arrive and are consumed from `sensor-telemetry-received`.
 8. Confirm `SensorReading`, `LastCommunication`, `BatteryLevel`, and threshold alerts are updated.
 9. Set `duplicateChancePercent` above zero if you want to verify `Duplicate` responses.
 10. Stop RabbitMQ and confirm the API does not return `Queued` while enqueueing is unavailable.
-11. If a consumer failure is easy to simulate locally, confirm messages move to `homecontrollerhub.sensor-telemetry_error` after retries.
+11. If a consumer failure is easy to simulate locally, confirm messages move to `sensor-telemetry-received_error` after retries.
 12. Open the frontend and validate dashboard readings, sensor detail charts, and alert spikes.
 
 ## Audit Logs
@@ -597,7 +596,6 @@ Important configuration areas:
 - `RabbitMq:VirtualHost`
 - `RabbitMq:Username`
 - `RabbitMq:Password`
-- `RabbitMq:QueueName`
 - `RabbitMq:PublishTimeoutSeconds`
 - `SensorHealthMonitoring:Enabled`
 - `SensorHealthMonitoring:IntervalSeconds`

--- a/src/HomeControllerHUB.Api/Consumers/IConsumerAssemblyMarker.cs
+++ b/src/HomeControllerHUB.Api/Consumers/IConsumerAssemblyMarker.cs
@@ -1,0 +1,5 @@
+namespace HomeControllerHUB.Api.Consumers;
+
+public interface IConsumerAssemblyMarker
+{
+}

--- a/src/HomeControllerHUB.Api/Extensions/MessageBusExtensions.cs
+++ b/src/HomeControllerHUB.Api/Extensions/MessageBusExtensions.cs
@@ -22,7 +22,7 @@ public static class MessageBusExtensions
         services.AddMassTransit(bus =>
         {
             bus.SetKebabCaseEndpointNameFormatter();
-            bus.AddConsumers(typeof(SensorTelemetryReceivedConsumer).Assembly);
+            bus.AddConsumers(typeof(IConsumerAssemblyMarker).Assembly);
             bus.AddConfigureEndpointsCallback((_, _, endpoint) =>
             {
                 var retryDelay = environment.IsEnvironment("Testing")

--- a/src/HomeControllerHUB.Api/Extensions/MessageBusExtensions.cs
+++ b/src/HomeControllerHUB.Api/Extensions/MessageBusExtensions.cs
@@ -21,17 +21,27 @@ public static class MessageBusExtensions
 
         services.AddMassTransit(bus =>
         {
-            bus.AddConsumer<SensorTelemetryReceivedConsumer>();
+            bus.SetKebabCaseEndpointNameFormatter();
+            bus.AddConsumers(typeof(SensorTelemetryReceivedConsumer).Assembly);
+            bus.AddConfigureEndpointsCallback((_, _, endpoint) =>
+            {
+                var retryDelay = environment.IsEnvironment("Testing")
+                    ? TimeSpan.FromSeconds(1)
+                    : TimeSpan.FromSeconds(2);
+
+                endpoint.UseMessageRetry(retry => retry.Interval(3, retryDelay));
+
+                if (endpoint is IRabbitMqReceiveEndpointConfigurator rabbitMqEndpoint)
+                {
+                    rabbitMqEndpoint.Durable = true;
+                }
+            });
 
             if (environment.IsEnvironment("Testing"))
             {
                 bus.UsingInMemory((context, cfg) =>
                 {
-                    cfg.ReceiveEndpoint(settings.QueueName, endpoint =>
-                    {
-                        endpoint.UseMessageRetry(retry => retry.Interval(3, TimeSpan.FromSeconds(1)));
-                        endpoint.ConfigureConsumer<SensorTelemetryReceivedConsumer>(context);
-                    });
+                    cfg.ConfigureEndpoints(context);
                 });
 
                 return;
@@ -45,12 +55,7 @@ public static class MessageBusExtensions
                     host.Password(settings.Password);
                 });
 
-                cfg.ReceiveEndpoint(settings.QueueName, endpoint =>
-                {
-                    endpoint.Durable = true;
-                    endpoint.UseMessageRetry(retry => retry.Interval(3, TimeSpan.FromSeconds(2)));
-                    endpoint.ConfigureConsumer<SensorTelemetryReceivedConsumer>(context);
-                });
+                cfg.ConfigureEndpoints(context);
             });
         });
 

--- a/src/HomeControllerHUB.Api/Messaging/MassTransitSensorTelemetryQueue.cs
+++ b/src/HomeControllerHUB.Api/Messaging/MassTransitSensorTelemetryQueue.cs
@@ -8,14 +8,14 @@ namespace HomeControllerHUB.Api.Messaging;
 
 public class MassTransitSensorTelemetryQueue : ISensorTelemetryQueue
 {
-    private readonly ISendEndpointProvider _sendEndpointProvider;
+    private readonly IPublishEndpoint _publishEndpoint;
     private readonly RabbitMqSettings _settings;
 
     public MassTransitSensorTelemetryQueue(
-        ISendEndpointProvider sendEndpointProvider,
+        IPublishEndpoint publishEndpoint,
         IOptions<RabbitMqSettings> settings)
     {
-        _sendEndpointProvider = sendEndpointProvider;
+        _publishEndpoint = publishEndpoint;
         _settings = settings.Value;
     }
 
@@ -24,7 +24,6 @@ public class MassTransitSensorTelemetryQueue : ISensorTelemetryQueue
         using var publishTimeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         publishTimeout.CancelAfter(TimeSpan.FromSeconds(Math.Max(_settings.PublishTimeoutSeconds, 1)));
 
-        var endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri($"queue:{_settings.QueueName}"));
-        await endpoint.Send(message, publishTimeout.Token);
+        await _publishEndpoint.Publish(message, publishTimeout.Token);
     }
 }

--- a/src/HomeControllerHUB.Api/Settings/RabbitMqSettings.cs
+++ b/src/HomeControllerHUB.Api/Settings/RabbitMqSettings.cs
@@ -9,12 +9,5 @@ public class RabbitMqSettings
     public string VirtualHost { get; set; } = "/";
     public string Username { get; set; } = "guest";
     public string Password { get; set; } = "guest";
-    public string QueueName { get; set; } = "homecontrollerhub.sensor-telemetry";
     public int PublishTimeoutSeconds { get; set; } = 5;
-
-    public string SensorTelemetryQueueName
-    {
-        get => QueueName;
-        set => QueueName = value;
-    }
 }

--- a/src/HomeControllerHUB.Api/appsettings.Development.json
+++ b/src/HomeControllerHUB.Api/appsettings.Development.json
@@ -46,7 +46,6 @@
     "VirtualHost": "/",
     "Username": "guest",
     "Password": "guest",
-    "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
   "SensorHealthMonitoring": {

--- a/src/HomeControllerHUB.Api/appsettings.Testing.json
+++ b/src/HomeControllerHUB.Api/appsettings.Testing.json
@@ -39,7 +39,6 @@
     "VirtualHost": "/",
     "Username": "guest",
     "Password": "guest",
-    "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
   "SensorHealthMonitoring": {

--- a/src/HomeControllerHUB.Api/appsettings.json
+++ b/src/HomeControllerHUB.Api/appsettings.json
@@ -18,7 +18,6 @@
     "VirtualHost": "/",
     "Username": "guest",
     "Password": "guest",
-    "QueueName": "homecontrollerhub.sensor-telemetry",
     "PublishTimeoutSeconds": 5
   },
   "SensorHealthMonitoring": {

--- a/tests/HomeControllerHUB.Api.IntegrationTests/MessageBusConfigurationTests.cs
+++ b/tests/HomeControllerHUB.Api.IntegrationTests/MessageBusConfigurationTests.cs
@@ -1,0 +1,17 @@
+using HomeControllerHUB.Api.Consumers;
+using MassTransit;
+
+namespace HomeControllerHUB.Api.IntegrationTests;
+
+public class MessageBusConfigurationTests
+{
+    [Fact]
+    public void Kebab_case_formatter_generates_expected_consumer_endpoint_name()
+    {
+        var formatter = new KebabCaseEndpointNameFormatter(includeNamespace: false);
+
+        var endpointName = formatter.Consumer<SensorTelemetryReceivedConsumer>();
+
+        Assert.Equal("sensor-telemetry-received", endpointName);
+    }
+}


### PR DESCRIPTION
## Summary

- Removes the fixed RabbitMQ `QueueName` setting from configuration.
- Registers MassTransit consumers by assembly instead of adding each consumer manually.
- Configures MassTransit endpoint names using kebab-case.
- Uses `ConfigureEndpoints(context)` for RabbitMQ and in-memory transports.
- Publishes telemetry messages by type with `IPublishEndpoint`, allowing MassTransit to route messages to the generated consumer endpoint.
- Adds coverage for the generated endpoint name.

## Details

- Consumers are registered from the `HomeControllerHUB.Api` assembly.
- The generated queue name for `SensorTelemetryReceivedConsumer` is confirmed as `sensor-telemetry-received`.
- Retry behavior was preserved:
  - Testing: 3 attempts with a 1-second interval.
  - Other environments: 3 attempts with a 2-second interval.
- RabbitMQ endpoints remain durable.

## Validation

- `dotnet build HomeControllerHUB.sln --configuration Release`
- Domain Tests: 1/1 passed.
- Application Tests: 189/189 passed.
- API Integration Tests: 12/12 passed.
- Telemetry publish/consume flow validated with in-memory transport.

## Notes

- MQTT was not implemented in this PR.
- RabbitMQ was not removed.
- Message contracts and payloads were not changed.
- Consumer processing logic was not changed.
- No migrations or database changes were made.
- No new secrets were added.
- Manual RabbitMQ validation was not executed because Docker Engine access was denied in the worktree environment.
- A preexisting NU1903 warning for `System.Security.Cryptography.Xml 9.0.17` was observed and intentionally left for a separate task.
